### PR TITLE
nbactions.xml excluded, manual car entry passing delay calculation error …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 #
 # individual files
 #
-/OSParking/nbactions.xml
+nbactions.xml
 #
 #
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml

--- a/OSParking/src/main/java/com/osparking/osparking/ControlGUI.java
+++ b/OSParking/src/main/java/com/osparking/osparking/ControlGUI.java
@@ -1495,8 +1495,8 @@ public class ControlGUI extends javax.swing.JFrame implements ActionListener, Ma
             }
         }
         int imageNo = randomInteger.nextInt(6) + 1;
-//        int imageNo = 5;
-       
+        
+        getPassingDelayStat()[gateNo].setICodeArrivalTime(System.currentTimeMillis());
         processCarArrival(gateNo, --manualSimulationImageID, dummyMessages[imageNo].getCarNumber(),
                 dummyMessages[imageNo].getBufferedImg());
     }//GEN-LAST:event_CarEnteredButtonActionPerformed


### PR DESCRIPTION
When the [Car Arrival] button is pressed on ContronGUI, the car passing delay had been calculated wrong. It is because the 1st image byte arrival wasn't recorded. I inserted a method call line to record the image arrival time.